### PR TITLE
fix: update elixir version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule MessagePack.Mixfile do
   def project do
     [ app: :message_pack,
       version: "0.2.0",
-      elixir: "~> 1.0.0 or ~> 0.15.1",
+      elixir: "~> 1.0 or ~> 0.15.1",
       deps: deps,
       build_per_environment: false,
 


### PR DESCRIPTION
fix:

```
$ mix test
** (Mix) You're trying to run :message_pack on Elixir v1.4.4 but it has declared in its mix.exs file it supports only Elixir ~> 1.0.0 or ~> 0.15.1
```